### PR TITLE
Improvements in the cover and titlepage, new variables.

### DIFF
--- a/components/cover.tex
+++ b/components/cover.tex
@@ -1,15 +1,6 @@
 % !TEX root = ../main.tex
-% The front cover for the TUM report document.
+% The front cover.
 % Included by MAIN.TEX
-
-
-%--------------------------------------------------
-% The Front Cover
-%--------------------------------------------------
-
-% The front cover for the TUM document.
-% Included by MAIN.TEX
-
 
 %--------------------------------------------------
 % The Front Cover
@@ -23,38 +14,20 @@
 
 \vspace{4cm}
 \begin{center}
+	\includegraphics[width=4cm]{\universityLogo}\\
+	\vspace{5mm}
+	\huge \program \\
+	\vspace{0.5cm}
+	\large \university
+\end{center}
 
-	  \includegraphics[width=4cm]{styles/tum_logo}
-
-	   \vspace{5mm}
-	   \huge Computational Science and Engineering \\(Int. Master's Program)\\
-	   \vspace{0.5cm}
-	 \large Technische Universit{\"a}t M{\"u}nchen\\
-    \vspace{1mm}
-
-	\end{center}
-
-
-\vspace{15mm}
+\vspace{20mm}
 \begin{center}
-
-   {\Large \doctype}
-
-  \vspace{20mm}
-
-  {\huge \textbf \title}\\
-
-
-  \vspace{15mm}
-
-
-  {\LARGE  \author}
-
-  \vspace{10mm}
-
-  \begin{figure}[h!]
-  \centering
-  \includegraphics[width=4cm]{styles/cse_logo}
-  \end{figure}
-
-  \end{center}
+	{\Large \doctype}\\
+	\vspace{20mm}
+	{\huge \textbf \title}\\
+	\vspace{15mm}
+	{\LARGE  \author}\\
+	\vspace{50mm}
+	\includegraphics[width=4cm]{\programLogo}
+\end{center}

--- a/components/info.tex
+++ b/components/info.tex
@@ -3,13 +3,18 @@
 % This file is used by MAIN.TEX
 
 % set title, authors and stuff for the cover
+\def\university{Technische Universit{\"a}t M{\"u}nchen}
+\def\universityLogo{styles/tum_logo}
+\def\program{Computational Science and Engineering \\(International Master's Program)}
+\def\programLogo{styles/cse_logo}
 \def\doctype{Master's Thesis}
+
 \def\title{My Ticket to a Masters Degree}
 \def\author{Your Name Here}
-\def\examinerOne{Prof. Dr. Computation}
-\def\examinerTwo{Univ.-Prof. Science}
-
-\def\date{April 1, 2222}
+\def\examinerOne{Univ.-Prof.\ Dr.\ Qui-Gon Jinn}
+\def\examinerTwo{Univ.-Prof.\ Dr.\ Obi-Wan Kenobi}
+\def\assistantAdvisor{Dr.\ rer.\ nat.\ Anakin Skywalker}
+\def\date{April 1st, 2222}
 
 % text to appear in the footer
 \def\footertext{}

--- a/components/titlepage.tex
+++ b/components/titlepage.tex
@@ -1,5 +1,5 @@
 % !TEX root = ../main.tex
-% The titlepage for the CAMP report document.
+% The titlepage.
 % Included by MAIN.TEX
 
 
@@ -13,54 +13,32 @@
 
 \thispagestyle{empty}
 
- \vspace{10mm}
+\vspace{4cm}
 \begin{center}
-	       %\oTUM{4cm}
-	       \includegraphics[width=4cm]{styles/tum_logo}
-
-	   \vspace{5mm}
-	   \huge Computational Science and Engineering \\(Int. Master's Program)\\
-	   \vspace{0.5cm}
-	 \large Technische Universit{\"a}t M{\"u}nchen\\
-
-	\end{center}
-
+    \includegraphics[width=4cm]{\universityLogo}\\
+    \vspace{5mm}
+    \huge \program \\
+    \vspace{0.5cm}
+    \large \university
+\end{center}
 
 \vspace{10mm}
 \begin{center}
+    {\Large \doctype}\\
+    \vspace{10mm}
+    {\LARGE \title}\\
+    \vspace{10mm}
 
-   {\Large \doctype}
-
-  \vspace{10mm}
-
-  {\LARGE \title}\\
-
-
-  \vspace{10mm}
-
-
-  %{\LARGE  \titleGer}\\
-
-
-  %\vspace{10mm}
-
-    %\hfill
     \begin{tabular}{ll}
-	   \Large Author:     & \Large \author \\[2mm]
-	   \Large $\mathrm{1^{st}}$ examiner:    & \Large \examinerOne\\[2mm]
-	   \Large $\mathrm{2^{nd}}$ examiner:    & \Large \examinerTwo \\[2mm]
-	  % \Large Assistant advisor(s):    & \Large N.A. \\[2mm]
-	   \Large Thesis handed in on:       & \Large \date
-	 \end{tabular}
+      \Large Author:                        & \Large \author \\[2mm]
+      \Large 1\textsuperscript{st} examiner:& \Large \examinerOne\\[2mm]
+      \Large 2\textsuperscript{nd} examiner:& \Large \examinerTwo \\[2mm]
+      \Large Assistant advisor:             & \Large \assistantAdvisor \\[2mm]
+      \Large Submission Date:               & \Large \date
+    \end{tabular}
 
-	 \vspace{5mm}
-
-	 \begin{figure}[h!]
-  \centering
-   \includegraphics[width=4cm]{styles/cse_logo}
-  \end{figure}
-
-
+    \vspace{50mm}
+    \includegraphics[width=4cm]{\programLogo}
 \end{center}
 
 % undo BCOR correction


### PR DESCRIPTION
1. Better vertical distribution of the elements. Now the bottom of the page is not empty.
2. Converted the `$\mathrm{1^{st}}$` to `1\textsuperscript{st}` for the examiners, in order to use the text font instead of the math one.
3.  Removed the (not needed) figure environment that was used to typeset the CSE logo.
4. Added a field about the assistan advisor (supervisor) and added it in the titlepage.
5. Moved the (duplicated) text about TUM and CSE, as well as their logos, in variables. This also allows for easier adaption to other programs.
6. Converted the "(Int. Master's Program)" to the full "(International Master's Program)". Please note that in the "certificate of appreciation" this is written "International Master's Program in Computational Science and Engineering".
7. Added spacing like "Prof.\ Dr.\ " instead of "Prof. Dr. ".
8. Changed the placeholder names for examiners to something less random. These Star Wars characters have a mentor-mentee relationship among them.
 
This closes #7, closes #8.