### PR TITLE
Fix: the date in the disclaimer was not the same as in the cover.

### DIFF
--- a/components/disclaimer.tex
+++ b/components/disclaimer.tex
@@ -1,7 +1,6 @@
 % !TEX root = ../main.tex
 \clearemptydoublepage
 
-
 \thispagestyle{empty}
 \selectlanguage{english}
 	\vspace*{0.8\textheight}
@@ -10,6 +9,6 @@
 	
 	\vspace{15mm}
 	\noindent
-	\today \hspace{5cm} \author
+	\date \hspace{5cm} \author
 \selectlanguage{english}
 \newpage


### PR DESCRIPTION
The cover and the titlepage use the `\date`, defined in the `components/info.tex`, while the disclaimer was using the `\today`.

This fixes #9.