### PR TITLE
Added PDF and XMP metadata, added keywords.

### DIFF
--- a/components/info.tex
+++ b/components/info.tex
@@ -16,5 +16,13 @@
 \def\assistantAdvisor{Dr.\ rer.\ nat.\ Anakin Skywalker}
 \def\date{April 1st, 2222}
 
+\def\keywords{{keyword1}, {keyword2}, {keyword3}}
+
+% The following are used for the PDF metadata, by default the same as above.
+\def\metaTitle{\title}
+\def\metaAuthor{\author}
+\def\metaSubject{\doctype\ -\ \university}
+\def\metaKeywords{\keywords}
+
 % text to appear in the footer
 \def\footertext{}

--- a/components/settings.tex
+++ b/components/settings.tex
@@ -174,9 +174,14 @@
 
 % PDF Metadata
 \hypersetup{
-  pdftitle={\title},%
-  pdfauthor={\author}
+  pdftitle={\metaTitle},%
+  pdfauthor={\metaAuthor},%
+  pdfkeywords={\metaKeywords},%
+  pdfsubject={\metaSubject}
 }
+
+% Create XMP Metadata (uses the values from hyperref)
+\usepackage{hyperxmp}
 
 % Make thumbnails (optional)
 % \usepackage{thumbpdf}


### PR DESCRIPTION
1. Configured the `hyperref` package to produce PDF metadata with Title, Author, Keywords and Subject. These values are set in the `components/info.tex` and they are by default the same as the defined for the cover. The subject is set as `\doctype\ -\ \university` and can easily be changed in the `components/info.tex`.

2. Added a variable `\keywords`, which is used in the metadata. This could also be incorporated in the abstract if needed.

3. Used the package `hyperxmp` to add also XMP metadata, the same as the ones set via `hyperref`.

This closes #22.