### PR TITLE
Support for longer titles

### DIFF
--- a/components/cover.tex
+++ b/components/cover.tex
@@ -28,6 +28,6 @@
 	{\huge \textbf \title}\\
 	\vspace{15mm}
 	{\LARGE  \author}\\
-	\vspace{50mm}
+	\vspace{\fill}
 	\includegraphics[width=4cm]{\programLogo}
 \end{center}

--- a/components/titlepage.tex
+++ b/components/titlepage.tex
@@ -37,7 +37,7 @@
       \Large Submission Date:               & \Large \date
     \end{tabular}
 
-    \vspace{50mm}
+    \vspace{\fill}
     \includegraphics[width=4cm]{\programLogo}
 \end{center}
 


### PR DESCRIPTION
Now loner titles (more than one line) will not break the format