### PR TITLE
Obsolete and depreciated options Fix

### DIFF
--- a/chapters/Introduction.tex
+++ b/chapters/Introduction.tex
@@ -11,6 +11,7 @@ Anyways your introduction goes here.
 
 
 Below a few \LaTeX examples are included for beginners
+\comment{You can also put comments in the margins for you or your advisor}
 \begin{figure}[ht]
   \centering
   \includegraphics[width=5cm]{images/swing_function_plot.png}

--- a/components/commands.tex
+++ b/components/commands.tex
@@ -115,7 +115,7 @@
 }
 
 % comment that appears on the border - very practical !!!
-\newcommand{\comment}[1]{\marginpar{\raggedright \noindent \footnotesize {\sl #1} }}
+\newcommand{\comment}[1]{\marginpar{\raggedright \noindent \footnotesize {\textsl{#1}} }}
 
 % page clearing
 \newcommand{\clearemptydoublepage}{%

--- a/main.tex
+++ b/main.tex
@@ -35,15 +35,15 @@
               index=totoc,
               headsepline,
               footsepline,
-              BCOR12mm,
-              DIV13]{scrbook}
+              BCOR=12mm,
+              DIV=13]{scrbook}
 
 % KOMA scrbook options:
 %  index=totoc: include an entry for the index in the table of contents.
 %  headsepline: use horizontal line under heading.
 %  footsepline: use horizontal line above footer.
-%  BCOR: binding correction (e.g.: BCOR12mm)
-%  DIV: Number of sheet sections (used for layout) (e.g.: DIV13)
+%  BCOR: binding correction (e.g.: BCOR=12mm)
+%  DIV: Number of sheet sections (used for layout) (e.g.: DIV=13)
 
 \input{components/info}
 


### PR DESCRIPTION
Fixes to depreciated and obsolete commands like 

- `\sl` to `\textsl{ }` 
- `BCOR12mm` to  `BCOR=12mm` 
- `DIV13` to `DIV=13`
-Added an example with` \comment{ }` command