### PR TITLE
Make glossary appear and fix its hyperlinks

### DIFF
--- a/chapters/Introduction.tex
+++ b/chapters/Introduction.tex
@@ -6,6 +6,8 @@ of \LaTeX.  A great resource for an introduction to \LaTeX\xspace is Tobias
 Oetiker's ''The Not So Short Introduction to \LaTeXe'' \cite{latex}.  Please
 page through that document
 before starting with your thesis.
+Oh, and let's use the mysterious word \gls{computer} here to give the glossary
+a reason to appear.
 \par
 Anyways your introduction goes here.
 

--- a/components/settings.tex
+++ b/components/settings.tex
@@ -34,6 +34,9 @@
 % Document structure
 %--------------------------------------------------
 
+% Pro­duce hy­per­text links in the doc­u­ment (recommended)
+\usepackage{hyperref}
+
 % Create glossaries and lists of acronyms
 \usepackage[toc, xindy]{glossaries}
 
@@ -157,9 +160,6 @@
 %--------------------------------------------------
 % PDF output
 %--------------------------------------------------
-
-% Pro­duce hy­per­text links in the doc­u­ment (recommended)
-\usepackage{hyperref}
 
 % Adjust the color of the links
 \hypersetup{

--- a/components/settings.tex
+++ b/components/settings.tex
@@ -38,6 +38,8 @@
 \usepackage{hyperref}
 
 % Create glossaries and lists of acronyms
+% depending on how many packages were shipped with your TeX distribution,
+% you might need to install xindy. On Linux: sudo apt install xindy
 \usepackage[toc, xindy]{glossaries}
 
 % Standard LaTeX package for creating indexes


### PR DESCRIPTION
I was confused how to make the **Glossary** appear until I realized I must first use (`\gls{}`) at least once on one of its entries in the text, just like the bibliography entries only appear if they are cited (`\cite{}`). To help avoid potential confusion of future users of this template I added a Glossary-keyword into the text.

Furthermore at least on my system (_Ubuntu 18.04, TeX Live distribution, Atom with latex package_) the hyperlinks from keyword to its Glossary-entry and back (from the page-index to its occurrence in the text) wasn't working until I moved `\usepackage{hyperref}` above `\usepackage[toc, xindy]{glossaries}`. I'd say it fits there nicely as well, from the section `% PDF output` to `% Document structure` :thinking: 